### PR TITLE
Simplify and improve m1-build-fix/Dockerfile

### DIFF
--- a/m1-build-fix/Dockerfile
+++ b/m1-build-fix/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 codecov/enterprise-api:latest-stable
 
 USER root
-RUN apk update && apk add openssl postgresql libgcc libstdc++ ncurses-libs
+RUN apk add --no-cache openssl postgresql libgcc libstdc++ ncurses-libs
 RUN ln -s /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s-a04fdf82.so.1
 USER codecov


### PR DESCRIPTION
Use single step `apk add` with `--no-cache`, instead of use two-step `apk update` + `apk add`, this change also help leave no temporary cache inside the Docker image, which will make the image a little bit smaller.