### PR TITLE
Improve usability of license.py

### DIFF
--- a/scripts/license.py
+++ b/scripts/license.py
@@ -58,17 +58,10 @@ def decode_license(license):
 
 
 def main(args=None):
-    expires = None
-    company = None
-    seats = None
-    repos = None
-    license = None
-    url = None
-    trial = True
 
     parser = argparse.ArgumentParser(prog='codecov key gen', add_help=True,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    subparsers = parser.add_subparsers(title='Commands')
+    subparsers = parser.add_subparsers(title='Commands', required=True)
 
     make = subparsers.add_parser('new')
     make.add_argument('--expires', action="store", required=True,


### PR DESCRIPTION
Removes unused arguments and marks required subparser as required.

Before:
```
✗ python scripts/license.py
Traceback (most recent call last):
  File "/Users/scottgigante/git/ctvc/codecov/scripts/license.py", line 93, in <module>
    main()
  File "/Users/scottgigante/git/ctvc/codecov/scripts/license.py", line 83, in main
    print(pref.command)
          ^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'command'
```

After:
```
✗ python scripts/license.py
usage: codecov key gen [-h] {new,check} ...
codecov key gen: error: the following arguments are required: {new,check}
```