### PR TITLE
update redis to 6.2 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - timescale
 
   redis:
-    image: redis:6-alpine
+    image: redis:6.2-alpine
     volumes:
       - redis-volume:/data
     networks:


### PR DESCRIPTION
https://github.com/codecov/worker/pull/707 uses an lpop argument that requires Redis 6.2