### PR TITLE
fix: Set auto_create_bucket to true

### DIFF
--- a/config/codecov.yml
+++ b/config/codecov.yml
@@ -29,6 +29,7 @@ services:
   minio:
     host: minio
     port: 9000
+    auto_create_bucket: true
 # If using external storage. Comment above and uncomment below
 #    host: s3.amazonaws.com or storage.googleapis.com if using GCS
 #    bucket: <bucket-name>


### PR DESCRIPTION
The old default config would not create the required minio bucket to accept uploads, this PR enables the auto_create_bucket toggle.
